### PR TITLE
Correct include syntax for docs publishing

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,1 +1,1 @@
-../README.md
+{!../README.md!}


### PR DESCRIPTION
The include syntax for MKDocs is not correctly used in this file - this needs to be corrected to allow docs publishing on docs.civicrm.org.

Please note also that you should amend your readme file for docs publishing to remove the link to GitHub for documentation as your documentation will be on docs.civicrm.org.