### PR TITLE
Fixing docs folder setup.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,1 +1,0 @@
-../README.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,1 @@
+../README.md


### PR DESCRIPTION
When including documentation (.md) files from outside the docs folder includes don't work. Instead we need to rely on trusty symlinks. 

The documentation for docs-publisher will be updated to clarify this.