### PR TITLE
Ensures TSYS works with the jQuery Validation update in CiviCRM 5.25

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -13,10 +13,10 @@
     <url desc="Documentation">https://docs.civicrm.org/tsys/en/latest/</url>
   </urls>
   <releaseDate>2019-01-10</releaseDate>
-  <version>1.2.0</version>
+  <version>1.2.1</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.13</ver>
+    <ver>5.25</ver>
   </compatibility>
   <civix>
     <namespace>CRM/Tsys</namespace>

--- a/js/civicrm_tsys.js
+++ b/js/civicrm_tsys.js
@@ -121,6 +121,8 @@ CRM.$(function ($) {
   });
 
   function loadtsysBillingBlock() {
+    // NOTE this SHOULD be removed when this issue gets fixed: https://lab.civicrm.org/dev/core/-/issues/1797
+    $('input#credit_card_number').removeClass('creditcard');
 
     // Get api key
     if (typeof CRM.vars.tsys.pp === 'undefined') {


### PR DESCRIPTION
Fixes submission of front end contribution forms using a TSYS processor for sites running CiviCRM 5.25 and up by resolving the console error: 

`TypeError: a.validator.methods[d] is undefined.  Exception occurred when checking element credit_card_number, check the 'creditcard' method. jquery.validate.min.js:4:11231`

Context
----------
The jQuery Validation plugin was updated in CiviCRM 5.25. the updated jQuery Validation code is choking on the credit card field (in core for all processors)... but this causes special issues with TSYS since TSYS uses javascript to process the transaction.

Until this [issue](https://lab.civicrm.org/dev/core/-/issues/1797) gets resolved in core this patch ensures the jquery validation plugin ignores the credit card field (which validates the credit card thru TSYS anyway) so that the rest of the javascript can run cleanly.

For more information see: https://lab.civicrm.org/dev/core/-/issues/1797

