### PR TITLE
Remove calls to deprecated CRM_Utils_Array::value

### DIFF
--- a/CRM/Core/Payment/Tsys.php
+++ b/CRM/Core/Payment/Tsys.php
@@ -125,7 +125,7 @@ class CRM_Core_Payment_Tsys extends CRM_Core_Payment {
     // Don't use \Civi::resources()->addScriptFile etc as they often don't work on AJAX loaded forms (eg. participant backend registration)
     \Civi::resources()->addVars('tsys', [
       'allApiKeys' => CRM_Core_Payment_Tsys::getAllTsysPaymentProcessors(),
-      'pp' => CRM_Utils_Array::value('id', $form->_paymentProcessor),
+      'pp' => $form->_paymentProcessor['id'] ?? NULL,
     ]);
     CRM_Core_Region::instance('billing-block')->add([
       'scriptUrl' => \Civi::resources()->getUrl(E::LONG_NAME, "js/civicrm_tsys.js"),
@@ -430,7 +430,7 @@ class CRM_Core_Payment_Tsys extends CRM_Core_Payment {
       $savedTokens = self::checkForSavedVaultToken($params['payment_processor_id'], $previousTransactionToken);
 
       // If transaction is recurring AND there is not an existing vault token saved, create a boarded card and save it
-      if (CRM_Utils_Array::value('is_recur', $params)
+      if (!empty($params['is_recur'])
       && $savedTokens == 0
       && !empty($params['contributionRecurID'])) {
         $paymentTokenId = CRM_Tsys_Recur::boardCard(

--- a/CRM/Tsys/Recur.php
+++ b/CRM/Tsys/Recur.php
@@ -79,7 +79,7 @@ class CRM_Tsys_Recur {
     }
     if (!empty($contributionResult)) {
       // Pass back the created id indirectly since I'm calling by reference.
-      $contribution['id'] = CRM_Utils_Array::value('id', $contributionResult);
+      $contribution['id'] = $contributionResult['id'] ?? NULL;
       // Connect to a membership if requested.
       if (!empty($options['membership_id'])) {
         try {

--- a/tsys.php
+++ b/tsys.php
@@ -185,7 +185,7 @@ function tsys_civicrm_buildForm($formName, &$form) {
     // work on AJAX loaded forms (eg. participant backend registration)
     \Civi::resources()->addVars('tsys', [
       'allApiKeys' => CRM_Core_Payment_Tsys::getAllTsysPaymentProcessors(),
-      'pp' => CRM_Utils_Array::value('id', $form->_paymentProcessor),
+      'pp' => $form->_paymentProcessor['id'] ?? NULL,
     ]);
     CRM_Core_Region::instance('billing-block')->add([
       'scriptUrl' => \Civi::resources()->getUrl(E::LONG_NAME, "js/civicrm_tsys.js"),
@@ -202,7 +202,7 @@ function tsys_civicrm_validateForm($formName, &$fields, &$files, &$form, &$error
 
   // ensure total amount is a positive number
   if ($formName == 'CRM_Tsys_Form_Device') {
-    $total = CRM_Utils_Array::value('total_amount', $fields );
+    $total = $fields['total_amount'] ?? NULL;
     if ($total < 0) {
       $errors['total_amount'] = E::ts( 'Total Amount must be a positive number' );
     }


### PR DESCRIPTION
Replaces deprecated function with equivalent null-coalescing operator. Behavior should be the same before/after.