### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/CRM/Core/Payment/Tsys.php
+++ b/CRM/Core/Payment/Tsys.php
@@ -146,7 +146,7 @@ class CRM_Core_Payment_Tsys extends CRM_Core_Payment {
         'id' => $paymentProcessorId,
       ));
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       $error = $e->getMessage();
       CRM_Core_Error::debug_log_message(E::ts('API Error %1', array(
         'domain' => 'com.aghstrategies.tsys',
@@ -180,7 +180,7 @@ class CRM_Core_Payment_Tsys extends CRM_Core_Payment {
         ],
       ]);
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       $error = $e->getMessage();
       CRM_Core_Error::debug_log_message(E::ts('API Error %1', array(
         'domain' => 'com.aghstrategies.tsys',
@@ -235,7 +235,7 @@ class CRM_Core_Payment_Tsys extends CRM_Core_Payment {
         'defaultCurrency' => "USD",
       ]);
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       $error = $e->getMessage();
       CRM_Core_Error::debug_log_message(E::ts('API Error %1', array(
         'domain' => 'com.aghstrategies.tsys',
@@ -393,7 +393,7 @@ class CRM_Core_Payment_Tsys extends CRM_Core_Payment {
         'token' => $vaultToken,
       ]);
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       $error = $e->getMessage();
       CRM_Core_Error::debug_log_message(E::ts('API Error %1', array(
         'domain' => 'com.aghstrategies.tsys',
@@ -547,7 +547,7 @@ class CRM_Core_Payment_Tsys extends CRM_Core_Payment {
                   'name' => $tsysCardTypes[$XMLvalueAsString],
                 ]);
               }
-              catch (CiviCRM_API3_Exception $e) {
+              catch (CRM_Core_Exception $e) {
                 $error = $e->getMessage();
                 CRM_Core_Error::debug_log_message(E::ts('API Error %1', array(
                   'domain' => 'com.aghstrategies.tsys',
@@ -658,7 +658,7 @@ class CRM_Core_Payment_Tsys extends CRM_Core_Payment {
         'trxn_id' => $params['trxn_id'],
       ]);
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       $error = $e->getMessage();
       CRM_Core_Error::debug_log_message(E::ts('API Error %1', array(
         'domain' => 'com.aghstrategies.tsys',
@@ -763,7 +763,7 @@ class CRM_Core_Payment_Tsys extends CRM_Core_Payment {
     try {
        $result = civicrm_api3('Setting', 'get', ['return' => 'tsys_devices']);
      }
-     catch (CiviCRM_API3_Exception $e) {
+     catch (CRM_Core_Exception $e) {
        $error = $e->getMessage();
        CRM_Core_Error::debug_log_message(E::ts('API Error %1', array(
          'domain' => 'com.aghstrategies.tsys',

--- a/CRM/Tsys/Form/Device.php
+++ b/CRM/Tsys/Form/Device.php
@@ -128,7 +128,7 @@ class CRM_Tsys_Form_Device extends CRM_Core_Form {
             try {
               $order = civicrm_api3('Order', 'create', $params);
             }
-            catch (CiviCRM_API3_Exception $e) {
+            catch (CRM_Core_Exception $e) {
               $error = $e->getMessage();
               CRM_Core_Error::debug_log_message(E::ts('API Error %1', array(
                 'domain' => 'com.aghstrategies.tsys',
@@ -149,7 +149,7 @@ class CRM_Tsys_Form_Device extends CRM_Core_Form {
                 'card_type_id' => $params['card_type_id'],
               ]);
             }
-            catch (CiviCRM_API3_Exception $e) {
+            catch (CRM_Core_Exception $e) {
               $error = $e->getMessage();
               CRM_Core_Error::debug_log_message(E::ts('API Error %1', array(
                 'domain' => 'com.aghstrategies.tsys',

--- a/CRM/Tsys/Form/Refund.php
+++ b/CRM/Tsys/Form/Refund.php
@@ -277,7 +277,7 @@ class CRM_Tsys_Form_Refund extends CRM_Core_Form {
     try {
       $updateTrxnStatus = civicrm_api3('Payment', 'create', $trxnParams);
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       $error = $e->getMessage();
       CRM_Core_Error::debug_log_message(E::ts('API Error %1', array(
         'domain' => 'com.aghstrategies.tsys',
@@ -296,7 +296,7 @@ class CRM_Tsys_Form_Refund extends CRM_Core_Form {
         'id' => $trxnParams['contribution_id'],
       ]);
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       $error = $e->getMessage();
       CRM_Core_Error::debug_log_message(E::ts('API Error %1', array(
         'domain' => 'com.aghstrategies.tsys',
@@ -312,7 +312,7 @@ class CRM_Tsys_Form_Refund extends CRM_Core_Form {
         'api.FinancialItem.get' => ['id' => "\$value.entity_id"],
       ]);
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       $error = $e->getMessage();
       CRM_Core_Error::debug_log_message(E::ts('API Error %1', array(
         'domain' => 'com.aghstrategies.tsys',
@@ -325,7 +325,7 @@ class CRM_Tsys_Form_Refund extends CRM_Core_Form {
         'id' => $eft['entity_id'],
       ]);
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       $error = $e->getMessage();
       CRM_Core_Error::debug_log_message(E::ts('API Error %1', array(
         'domain' => 'com.aghstrategies.tsys',
@@ -348,7 +348,7 @@ class CRM_Tsys_Form_Refund extends CRM_Core_Form {
     try {
       $createFinItem = civicrm_api3('FinancialItem', 'create', $finItemParams);
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       $error = $e->getMessage();
       CRM_Core_Error::debug_log_message(E::ts('API Error %1', array(
         'domain' => 'com.aghstrategies.tsys',
@@ -365,7 +365,7 @@ class CRM_Tsys_Form_Refund extends CRM_Core_Form {
         'amount' => $updateTrxnStatus['values'][$updateTrxnStatus['id']]['total_amount'],
       ]);
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       $error = $e->getMessage();
       CRM_Core_Error::debug_log_message(E::ts('API Error %1', array(
         'domain' => 'com.aghstrategies.tsys',

--- a/CRM/Tsys/Form/Settings/Device.php
+++ b/CRM/Tsys/Form/Settings/Device.php
@@ -29,7 +29,7 @@ class CRM_Tsys_Form_Settings_Device extends CRM_Core_Form {
           'tsys_devices' => $deviceSettings,
         ]);
       }
-      catch (CiviCRM_API3_Exception $e) {
+      catch (CRM_Core_Exception $e) {
         $error = $e->getMessage();
         CRM_Core_Error::debug_log_message(E::ts('API Error %1', [
           'domain' => 'com.aghstrategies.tsys',
@@ -118,7 +118,7 @@ class CRM_Tsys_Form_Settings_Device extends CRM_Core_Form {
           'tsys_devices' => $deviceSettings,
         ]);
       }
-      catch (CiviCRM_API3_Exception $e) {
+      catch (CRM_Core_Exception $e) {
         $error = $e->getMessage();
         CRM_Core_Error::debug_log_message(E::ts('API Error %1', [
           'domain' => 'com.aghstrategies.tsys',

--- a/CRM/Tsys/Form/Tsysdevicepayment.php
+++ b/CRM/Tsys/Form/Tsysdevicepayment.php
@@ -125,7 +125,7 @@ class CRM_Tsys_Form_Tsysdevicepayment extends CRM_Core_Form {
                 'card_type_id' => $params['card_type_id'],
               ]);
             }
-            catch (CiviCRM_API3_Exception $e) {
+            catch (CRM_Core_Exception $e) {
               $error = $e->getMessage();
               CRM_Core_Error::debug_log_message(E::ts('API Error %1', array(
                 'domain' => 'com.aghstrategies.tsys',

--- a/CRM/Tsys/Recur.php
+++ b/CRM/Tsys/Recur.php
@@ -31,7 +31,7 @@ class CRM_Tsys_Recur {
         'id' => $contribution['contribution_recur_id'],
       ]);
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       $error = $e->getMessage();
       CRM_Core_Error::debug_log_message(E::ts('API Error %1', array(
         'domain' => 'com.aghstrategies.tsys',
@@ -70,7 +70,7 @@ class CRM_Tsys_Recur {
     try {
       $contributionResult = civicrm_api3('contribution', 'create', $contribution);
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       $error = $e->getMessage();
       CRM_Core_Error::debug_log_message(E::ts('API Error %1', array(
         'domain' => 'com.aghstrategies.tsys',
@@ -88,7 +88,7 @@ class CRM_Tsys_Recur {
            'membership_id' => $options['membership_id']
          ));
         }
-        catch (CiviCRM_API3_Exception $e) {
+        catch (CRM_Core_Exception $e) {
           $error = $e->getMessage();
           CRM_Core_Error::debug_log_message(E::ts('API Error %1', array(
             'domain' => 'com.aghstrategies.tsys',
@@ -108,7 +108,7 @@ class CRM_Tsys_Recur {
         try {
          $contributionResult = civicrm_api3('contribution', 'completetransaction', $complete);
         }
-        catch (CiviCRM_API3_Exception $e) {
+        catch (CRM_Core_Exception $e) {
           $error = $e->getMessage();
           CRM_Core_Error::debug_log_message(E::ts('API Error %1', array(
             'domain' => 'com.aghstrategies.tsys',
@@ -188,7 +188,7 @@ class CRM_Tsys_Recur {
     try {
       $ogContribution = civicrm_api3('contribution', 'get', $get);
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       $error = $e->getMessage();
       CRM_Core_Error::debug_log_message(E::ts('API Error %1', array(
         'domain' => 'com.aghstrategies.tsys',
@@ -207,7 +207,7 @@ class CRM_Tsys_Recur {
       try {
         $lineItem = civicrm_api3('LineItem', 'get', $get);
       }
-      catch (CiviCRM_API3_Exception $e) {
+      catch (CRM_Core_Exception $e) {
         $error = $e->getMessage();
         CRM_Core_Error::debug_log_message(E::ts('API Error %1', array(
           'domain' => 'com.aghstrategies.tsys',
@@ -318,7 +318,7 @@ class CRM_Tsys_Recur {
           'token' => $vaultToken,
         ]);
       }
-      catch (CiviCRM_API3_Exception $e) {
+      catch (CRM_Core_Exception $e) {
         $error = $e->getMessage();
         CRM_Core_Error::debug_log_message(E::ts('API Error %1', array(
           'domain' => 'com.aghstrategies.tsys',
@@ -333,7 +333,7 @@ class CRM_Tsys_Recur {
             'processor_id' => $paymentProcessor,
           ]);
         }
-        catch (CiviCRM_API3_Exception $e) {
+        catch (CRM_Core_Exception $e) {
           $error = $e->getMessage();
           CRM_Core_Error::debug_log_message(E::ts('API Error %1', array(
             'domain' => 'com.aghstrategies.tsys',

--- a/api/v3/Job/Tsysrecurringcontributions.php
+++ b/api/v3/Job/Tsysrecurringcontributions.php
@@ -58,7 +58,7 @@ function _civicrm_api3_job_tsysrecurringcontributions_spec(&$spec) {
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_job_tsysrecurringcontributions($params) {
   // Running this job in parallel could generate bad duplicate contributions.
@@ -97,7 +97,7 @@ function civicrm_api3_job_tsysrecurringcontributions($params) {
             'id' => $dao->id,
           ]);
         }
-        catch (CiviCRM_API3_Exception $e) {
+        catch (CRM_Core_Exception $e) {
           $error = $e->getMessage();
           CRM_Core_Error::debug_log_message(E::ts('API Error %1', array(
             'domain' => 'com.aghstrategies.tsys',
@@ -119,7 +119,7 @@ function civicrm_api3_job_tsysrecurringcontributions($params) {
             'id' => $dao->id,
           ]);
         }
-        catch (CiviCRM_API3_Exception $e) {
+        catch (CRM_Core_Exception $e) {
           $error = $e->getMessage();
           CRM_Core_Error::debug_log_message(E::ts('API Error %1', array(
             'domain' => 'com.aghstrategies.tsys',
@@ -164,7 +164,7 @@ function civicrm_api3_job_tsysrecurringcontributions($params) {
   try {
     $recurringDonations = civicrm_api3('ContributionRecur', 'get', $recurParams);
   }
-  catch (CiviCRM_API3_Exception $e) {
+  catch (CRM_Core_Exception $e) {
     $error = $e->getMessage();
     CRM_Core_Error::debug_log_message(E::ts('API Error %1', array(
       'domain' => 'com.aghstrategies.tsys',
@@ -233,7 +233,7 @@ function civicrm_api3_job_tsysrecurringcontributions($params) {
             $options['membership_id'] = $membership_payment['membership_id'];
           }
         }
-        catch (CiviCRM_API3_Exception $e) {
+        catch (CRM_Core_Exception $e) {
           $error = $e->getMessage();
           CRM_Core_Error::debug_log_message(E::ts('API Error %1', array(
             'domain' => 'com.aghstrategies.tsys',
@@ -275,7 +275,7 @@ function civicrm_api3_job_tsysrecurringcontributions($params) {
       try {
         $recurUpdate = civicrm_api3('ContributionRecur', 'create', $contribution_recur_set);
       }
-      catch (CiviCRM_API3_Exception $e) {
+      catch (CRM_Core_Exception $e) {
         $error = $e->getMessage();
         CRM_Core_Error::debug_log_message(E::ts('API Error %1', array(
           'domain' => 'com.aghstrategies.tsys',
@@ -295,7 +295,7 @@ function civicrm_api3_job_tsysrecurringcontributions($params) {
           ]
         );
       }
-      catch (CiviCRM_API3_Exception $e) {
+      catch (CRM_Core_Exception $e) {
         $error = $e->getMessage();
         CRM_Core_Error::debug_log_message(E::ts('API Error %1', array(
           'domain' => 'com.aghstrategies.tsys',
@@ -334,7 +334,7 @@ function civicrm_api3_job_tsysrecurringcontributions($params) {
           'id' => $dao->id,
         ]);
       }
-      catch (CiviCRM_API3_Exception $e) {
+      catch (CRM_Core_Exception $e) {
         $error = $e->getMessage();
         CRM_Core_Error::debug_log_message(E::ts('API Error %1', array(
           'domain' => 'com.aghstrategies.tsys',

--- a/tests/phpunit/CRM/Tsys/BaseTest.php
+++ b/tests/phpunit/CRM/Tsys/BaseTest.php
@@ -69,7 +69,7 @@ class CRM_Tsys_BaseTest extends \PHPUnit\Framework\TestCase implements HeadlessI
     try {
       $recurJob = civicrm_api3('job', 'tsysrecurringcontributions');
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       $error = $e->getMessage();
     }
     if (!empty($recurJob)) {
@@ -256,7 +256,7 @@ class CRM_Tsys_BaseTest extends \PHPUnit\Framework\TestCase implements HeadlessI
     try {
       $contribution = civicrm_api3('Contribution', 'transact', $params);
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       $error = $e->getMessage();
       CRM_Core_Error::debug_log_message(ts('API Error %1', array(
         'domain' => 'com.aghstrategies.tsys',

--- a/tests/phpunit/CRM/Tsys/OneTimeContributionTsysTest.php
+++ b/tests/phpunit/CRM/Tsys/OneTimeContributionTsysTest.php
@@ -153,7 +153,7 @@ class CRM_Tsys_OneTimeContributionTsysTest extends CRM_Tsys_BaseTest {
       try {
         $contribution = civicrm_api3('Contribution', 'transact', $params);
       }
-      catch (CiviCRM_API3_Exception $e) {
+      catch (CRM_Core_Exception $e) {
         $error = $e->getMessage();
         CRM_Core_Error::debug_log_message(ts('API Error %1', array(
           'domain' => 'com.aghstrategies.tsys',

--- a/tsys.php
+++ b/tsys.php
@@ -19,7 +19,7 @@ function tsys_civicrm_links($op, $objectName, $objectId, &$links, &$mask, &$valu
           'id' => $objectId,
         ]);
       }
-      catch (CiviCRM_API3_Exception $e) {
+      catch (CRM_Core_Exception $e) {
         $error = $e->getMessage();
         CRM_Core_Error::debug_log_message(E::ts('API Error %1', array(
           'domain' => 'com.aghstrategies.tsys',
@@ -54,7 +54,7 @@ function tsys_civicrm_links($op, $objectName, $objectId, &$links, &$mask, &$valu
           'id' => $values['contribution_id'],
         ]);
       }
-      catch (CiviCRM_API3_Exception $e) {
+      catch (CRM_Core_Exception $e) {
         $error = $e->getMessage();
         CRM_Core_Error::debug_log_message(E::ts('API Error %1', array(
           'domain' => 'com.aghstrategies.tsys',
@@ -70,7 +70,7 @@ function tsys_civicrm_links($op, $objectName, $objectId, &$links, &$mask, &$valu
             'id' => $values['id'],
           ]);
         }
-        catch (CiviCRM_API3_Exception $e) {
+        catch (CRM_Core_Exception $e) {
           $error = $e->getMessage();
           CRM_Core_Error::debug_log_message(E::ts('API Error %1', array(
             'domain' => 'com.aghstrategies.tsys',
@@ -293,7 +293,7 @@ function tsys_civicrm_check(&$messages) {
       'is_test' => 0,
     ]);
   }
-  catch (CiviCRM_API3_Exception $e) {
+  catch (CRM_Core_Exception $e) {
     $error = $e->getMessage();
     CRM_Core_Error::debug_log_message(E::ts('API Error %1', array(
       'domain' => 'com.aghstrategies.tsys',
@@ -338,7 +338,7 @@ function tsys_civicrm_check(&$messages) {
           'payment_processor_id' => ['IN' => $processors],
         ]);
       }
-      catch (CiviCRM_API3_Exception $e) {
+      catch (CRM_Core_Exception $e) {
         $error = $e->getMessage();
         CRM_Core_Error::debug_log_message(E::ts('API Error %1', array(
           'domain' => 'com.aghstrategies.tsys',
@@ -355,7 +355,7 @@ function tsys_civicrm_check(&$messages) {
               'contribution_status_id' => "Completed",
             ]);
           }
-          catch (CiviCRM_API3_Exception $e) {
+          catch (CRM_Core_Exception $e) {
             $error = $e->getMessage();
             CRM_Core_Error::debug_log_message(ts('API Error %1', array(
               'domain' => 'com.aghstrategies.tsys',


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.