### PR TITLE
Remove deprecated curl_close

### DIFF
--- a/CRM/Tsys/Soap.php
+++ b/CRM/Tsys/Soap.php
@@ -378,12 +378,10 @@ HEREDOC;
 
     if ($response === false) {
       $err = 'Curl error: ' . curl_error($soap_do);
-      curl_close($soap_do);
       // print $err;
       $xml = $err;
     }
     else {
-      curl_close($soap_do);
       $response = str_ireplace(['SOAP-ENV:', 'SOAP:'], '', $response);
       $xml = simplexml_load_string($response);
     }


### PR DESCRIPTION
This function is deprecated; as of php 8.0 it does nothing.
See https://www.php.net/manual/en/function.curl-close.php